### PR TITLE
suppression version de node la moins récente et ajout détails noms scripts

### DIFF
--- a/.github/workflows/publication.yml
+++ b/.github/workflows/publication.yml
@@ -1,4 +1,4 @@
-name: pokemon-front-test
+name: pokemon-front
 
 on:
   pull_request:
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [ 14.x, 16.x, 18.x ]
+        node-version: [ 16.x, 18.x ]
 
     steps:
       - name: Checkout code
@@ -27,14 +27,14 @@ jobs:
       - name: Lancement des tests
         run: npm test
 
-      - name: docker login
+      - name: Connexion à docker
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Création de l'image Docker
+      - name: Création de l'image Docker et envoie sur le registry
         run: |
           docker build . -t ghcr.io/davalenzo/pokemon-front-test:${{ matrix.node-version }}
           docker run ghcr.io/davalenzo/pokemon-front-test:${{ matrix.node-version }}


### PR DESCRIPTION
La version 14 est ancienne et le test prend beaucoup de temps. Nous l'enlevons pour rendre l'action github plus rapide