### PR TITLE
Changement de version connexion a docker sur le github action

### DIFF
--- a/.github/workflows/publication.yml
+++ b/.github/workflows/publication.yml
@@ -28,7 +28,7 @@ jobs:
         run: npm test
 
       - name: Connexion à docker
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}


### PR DESCRIPTION
# Objectif 🥇 

 L'ancienne version de docker/login étant dépréciée. J'ai mis à jour à la version 2.1.0 afin de ne plus avoir l'avertissement lors de la création de l'image docker